### PR TITLE
Update plugin.coffee for new wintersmith API

### DIFF
--- a/plugin.coffee
+++ b/plugin.coffee
@@ -8,31 +8,33 @@ module.exports = (wintersmith, callback) ->
 
   class StylusPlugin extends wintersmith.ContentPlugin
 
-    constructor: (@_filename, @_base, @_text) ->
+    constructor: (@_filepath, @_text) ->
 
     getFilename: ->
-      @_filename.replace /styl$/, 'css'
+      @_filepath.relative.replace /styl$/, 'css'
 
-    render: (locals, contents, templates, callback) ->
-      try
-        stylus(@_text)
-        .set('filename', this.getFilename())
-        .set('paths', [path.dirname(path.join(@_base, @_filename))])
-        .use(nib())
-        .render (err, css) ->
-          if err
-            callback err
-          else
-            callback null, new Buffer css
-      catch error
-        callback error
-
-  StylusPlugin.fromFile = (filename, base, callback) ->
-    fs.readFile path.join(base, filename), (error, buffer) ->
+    getView: ->
+      return (evn, locals, contents, templates, callback) ->
+        try
+          stylus(@_text)
+          .set('filename', this.getFilename())
+          .set('paths', [path.dirname(@_filepath.full)])
+          .use(nib())
+          .render (err, css) ->
+            if err
+              callback err
+            else
+              callback null, new Buffer css
+        catch error
+          callback error
+      
+      
+  StylusPlugin.fromFile = (filepath, callback) ->
+    fs.readFile filepath.full, (error, buffer) ->
       if error
         callback error
       else
-        callback null, new StylusPlugin filename, base, buffer.toString()
+        callback null, new StylusPlugin filepath, buffer.toString()
 
   wintersmith.registerContentPlugin 'styles', '**/*.styl', StylusPlugin
   callback()


### PR DESCRIPTION
Improved compatibility with wintersmith API.
Caused error: "error Arguments to path.join must be strings"
