### PR TITLE
Add stylus inline sprite features to CSS.  

### DIFF
--- a/plugin.coffee
+++ b/plugin.coffee
@@ -21,6 +21,9 @@ module.exports = (env, callback) ->
           options.paths = [path.dirname(@_filepath.full)]
           stylus(@_text, options)
           .use(nib())
+          .define('url', stylus.url(
+            paths : [__dirname + '/public']
+            limit : locals.inlineSpriteMaxBytes || 0 ) )
           .render (err, css) ->
             if err
               callback err


### PR DESCRIPTION
Set locals.inlineSpriteMaxBytes to max bytes to inline.  Defaults to 0.

This exposes the functionality in Stylus described here: http://bengourley.co.uk/using-stylus

This change only takes effect if a variable is config'd in locals.json:

```
{
  "locals": {
      "inlineSpriteMaxBytes" : 10000
  }
}
```
