### PR TITLE
Register CoffeeScript extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
-require('coffee-script');
+var coffee = require('coffee-script');
+if (coffee.register) coffee.register();
 module.exports = require('./plugin');


### PR DESCRIPTION
As of CoffeeScript 1.7, the `.coffee` extension is no longer register with the module loader automatically. This breaks the plugin. Calling `coffee.register()` allows you to require CoffeeScript files normally. 

I know there haven't been any updates to this repo in nearly a year, but I figured I'd send a pull since it's a breaking change. 
