### PR TITLE
Updating coffee-script, adjusting mocha options accordingly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
-var coffee = require('coffee-script');
-if (coffee.register) coffee.register();
+require('coffee-script/register');
 module.exports = require('./plugin');

--- a/package.json
+++ b/package.json
@@ -1,19 +1,22 @@
 {
   "name": "wintersmith-stylus",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Jon Wong <j@jnwng.com>",
   "description": "stylus plugin for wintersmith",
-  "keywords": ["wintersmith-plugin"],
+  "keywords": [
+    "wintersmith-plugin"
+  ],
   "license": "MIT",
   "dependencies": {
-    "stylus": ">=0.19.x",
-    "nib": ">=0.4.0",
-    "async": ">= 0.0.1",
-    "coffee-script": ">=1.2.x"
+    "coffee-script": "^1.7.1",
+    "nib": "^1.0.3",
+    "stylus": ">=0.19.x"
   },
-
   "devDependencies": {
-    "wintersmith": ">=2.0.0",
-    "mocha": ">=1.0.0"
+    "mocha": "^1.21.3",
+    "wintersmith": "^2.1.0"
+  },
+  "scripts": {
+    "test": "./node_modules/mocha/bin/mocha -R spec"
   }
 }

--- a/plugin.coffee
+++ b/plugin.coffee
@@ -1,7 +1,6 @@
 stylus = require 'stylus'
 nib    = require 'nib'
 path = require 'path'
-async = require 'async'
 fs = require 'fs'
 
 module.exports = (env, callback) ->
@@ -20,12 +19,12 @@ module.exports = (env, callback) ->
           options.filename = this.getFilename()
           options.paths = [path.dirname(@_filepath.full)]
           stylus(@_text, options)
-          .use(nib())
-          .render (err, css) ->
-            if err
-              callback err
-            else
-              callback null, new Buffer css
+            .use(nib())
+            .render (err, css) ->
+              if err
+                callback err
+              else
+                callback null, new Buffer css
         catch error
           callback error
 
@@ -34,7 +33,7 @@ module.exports = (env, callback) ->
       if error
         callback error
       else
-        callback null, new StylusPlugin filepath, buffer.toString()
+        callback null, new StylusPlugin(filepath, buffer.toString())
 
   env.registerContentPlugin 'styles', '**/*.styl', StylusPlugin
-  callback()
+  do callback

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers coffee:coffee-script
+--compilers coffee:coffee-script/register

--- a/test/nib.coffee
+++ b/test/nib.coffee
@@ -1,19 +1,15 @@
-wintersmith  = require('wintersmith')
-Config       = require('wintersmith/src/core/config').Config
-wsStylus     = require('./../')
+wintersmith = require 'wintersmith'
+{Config} = require 'wintersmith/src/core/config'
+wsStylus = require './../'
 
 # new wintersmith environment
-env = wintersmith(new Config, __dirname)
+env = wintersmith new Config, __dirname
 
 describe "Nib integration", ->
 
   beforeEach (done)->
-
     # Install this plugin onto wintersmith
-    wsStylus env, ->
-
-      # Installed, now wintersmith can handle .styl
-      done()
+    wsStylus env, done
 
   it "should compile stylus with nib", (done)->
 
@@ -30,5 +26,5 @@ describe "Nib integration", ->
             -moz-box-shadow: 0 0 1px #000;
             box-shadow: 0 0 1px #000;
           }""")
-        # yay
-        done()
+
+        do done


### PR DESCRIPTION
@bendrucker I've gone ahead and made coffee-script 1.7.1 a dependency of this library, so that we can better reason about the state of this module when testing (and registering).

Unless there are objections, I will be merging this and releasing to npm by July 31st, 8PM.