### PR TITLE
allow to use other stylus plugins beside nib

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.4.0",
   "author": "Jon Wong <j@jnwng.com>",
   "description": "stylus plugin for wintersmith",
-  "keywords": ["wintersmith-plugin"],
+  "keywords": [
+    "wintersmith-plugin"
+  ],
   "license": "MIT",
   "dependencies": {
     "stylus": ">=0.19.x",
@@ -11,9 +13,9 @@
     "async": ">= 0.0.1",
     "coffee-script": ">=1.2.x"
   },
-
   "devDependencies": {
     "wintersmith": ">=2.0.0",
-    "mocha": ">=1.0.0"
+    "mocha": ">=1.0.0",
+    "should": "~4.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wintersmith-stylus",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Jon Wong <j@jnwng.com>",
   "description": "stylus plugin for wintersmith",
   "keywords": ["wintersmith-plugin"],

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,3 @@
---compilers coffee:coffee-script
+--require should
+--ui bdd
+--compilers coffee:coffee-script/register

--- a/test/nib.coffee
+++ b/test/nib.coffee
@@ -4,6 +4,9 @@ wsStylus     = require('./../')
 
 # new wintersmith environment
 env = wintersmith(new Config, __dirname)
+env.config.stylus ?= {}
+env.config.stylus.dependencies = []
+env.config.stylus.dependencies.push 'nib'
 
 describe "Nib integration", ->
 
@@ -24,11 +27,15 @@ describe "Nib integration", ->
       tree['style.styl'].getView() env, null, null, null, (err, content)->
 
         if content?
-          content.should.equal("""
+          content.toString().should.equal("""
           body {
             -webkit-box-shadow: 0 0 1px #000;
-            -moz-box-shadow: 0 0 1px #000;
             box-shadow: 0 0 1px #000;
-          }""")
+          }
+
+          """)
+        else
+          throw err
+
         # yay
         done()


### PR DESCRIPTION
Hey, 

i hacked a little bit to make your plugin just a little bit more flexible in using other stylus plugins like jeet or something like that. Beside that nib can be configured now in the same way by adding it to the project dependencies. 

Would be nice if you would think about merging this PR!

Thanks, Falk